### PR TITLE
🚀 Update dependencies: Fri Apr 20 08:30:49 UTC 2018

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "node-updater-test",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "react": "^15.0.0"
+    "react": "16.3.2"
   }
 }

--- a/sub-project/package.json
+++ b/sub-project/package.json
@@ -1,9 +1,9 @@
 {
   "name": "sub-project",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^3.0.0"
+    "lodash": "4.17.5"
   }
 }

--- a/sub-project/yarn.lock
+++ b/sub-project/yarn.lock
@@ -2,6 +2,6 @@
 # yarn lockfile v1
 
 
-lodash@^3.0.0:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+lodash@4.17.5:
+  version "4.17.5"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/lodash/-/lodash-4.17.5.tgz?dl=https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,21 +4,21 @@
 
 asap@~2.0.3:
   version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/asap/-/asap-2.0.6.tgz?dl=https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
 core-js@^1.0.0:
   version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/core-js/-/core-js-1.2.7.tgz?dl=https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
 encoding@^0.1.11:
   version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/encoding/-/encoding-0.1.12.tgz?dl=https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
     iconv-lite "~0.4.13"
 
 fbjs@^0.8.16:
   version "0.8.16"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/fbjs/-/fbjs-0.8.16.tgz?dl=https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -30,59 +30,59 @@ fbjs@^0.8.16:
 
 iconv-lite@~0.4.13:
   version "0.4.21"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/iconv-lite/-/iconv-lite-0.4.21.tgz?dl=https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
   dependencies:
     safer-buffer "^2.1.0"
 
 is-stream@^1.0.1:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/is-stream/-/is-stream-1.1.0.tgz?dl=https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
 isomorphic-fetch@^2.1.1:
   version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz?dl=https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   dependencies:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
 
 js-tokens@^3.0.0:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/js-tokens/-/js-tokens-3.0.2.tgz?dl=https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/loose-envify/-/loose-envify-1.3.1.tgz?dl=https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
 
 node-fetch@^1.0.1:
   version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/node-fetch/-/node-fetch-1.7.3.tgz?dl=https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
 object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz?dl=https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
 promise@^7.1.1:
   version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/promise/-/promise-7.3.1.tgz?dl=https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
   dependencies:
     asap "~2.0.3"
 
 prop-types@^15.6.0:
   version "15.6.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/prop-types/-/prop-types-15.6.1.tgz?dl=https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-react@^16.3.2:
+react@16.3.2:
   version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/react/-/react-16.3.2.tgz?dl=https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -91,16 +91,16 @@ react@^16.3.2:
 
 safer-buffer@^2.1.0:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/safer-buffer/-/safer-buffer-2.1.2.tgz?dl=https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 setimmediate@^1.0.5:
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/setimmediate/-/setimmediate-1.0.5.tgz?dl=https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/ua-parser-js/-/ua-parser-js-0.7.17.tgz?dl=https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
 whatwg-fetch@>=0.10.0:
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
+  resolved "https://mmrepo.jfrog.io/mmrepo/api/npm/npm-virtual/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz?dl=https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"


### PR DESCRIPTION
### :robot: Updated depedencies:
<details>
  <summary> react  ^15.0.0  →  16.3.2 </summary>
  
.16.3.2 / 2018-04-16
===================

  * Add 16.3.2 changelog ([#12621](https://github.com/facebook/react/issues/12621))
  * Update bundle sizes for 16.3.2 release
  * Update error codes for 16.3.2 release
  * Updating package versions for release 16.3.2
  * Updating yarn.lock file for 16.3.2 release
  * Fix documentation of the release process ([#12337](https://github.com/facebook/react/issues/12337))
    * Adusted grammar in release script readme.
    * Adjusts title and explanation about the release process.
  * Fix small typos in create-subscription readme ([#12399](https://github.com/facebook/react/issues/12399))
  * tests: add regression test for reading ReactCurrentOwner stateNode ([#12412](https://github.com/facebook/react/issues/12412))
    * tests: add regression test for reading ReactCurrentOwner stateNode
    * tests: replace expect with just rendering the component
  * Update GCC ([#12618](https://github.com/facebook/react/issues/12618))
  * Fixed debug performance labels for new component types ([#12609](https://github.com/facebook/react/issues/12609))
    * Added new debug performance tests for AsyncMode, StrictMode, forwardRef, and context provider/consumer components.
    * Updated performance labels to exclude AsyncMode and StrictMode.
    * Added labels for forwardRef (and inner function) that mirror DevTools labels.
  * [Danger] Minor fixes ([#12606](https://github.com/facebook/react/issues/12606))
    * Don't download bundle stats from master on CI
    This was temporarily necessary in the past because we didn't have the logic that downloads actual *merge base* stats.
    We do have that now as part of the Danger script. So we can remove this.
    * Use absolute threshold for whether to show a change
    * Download master stats, but only for other master builds
    * Rewrite sizes
  * Bump expiration for interactive updates to 150ms in production ([#12599](https://github.com/facebook/react/issues/12599))
    * Bump expiration for interactive updates to 150ms in production
    **what is the change?:**
    Changes the expiration deadline from 500ms to 150ms, only in production.
    In development it will still be 500ms.
    I'm thinking we may want to change the 'bucket size' too, will look into
    that a bit.
    **why make this change?:**
    We need to ensure interactions are responsive enough in order to gather
    more test data on async. mode.
    **test plan:**
    No tests failed - where shall we add a test for this?
    * Add comments
  * Remove @providesModule in www shims
  * Added UMD build to test renderer package ([#12594](https://github.com/facebook/react/issues/12594))
  * Fixes language in error message. ([#12590](https://github.com/facebook/react/issues/12590))
  * createReactNativeComponentClass needs to be CommonJS
    oops
  * Refactor findHostInstance and findNodeHandle ([#12575](https://github.com/facebook/react/issues/12575))
    * Move findNodeHandle into the renderers and use instantiation
    This is just like ReactDOM does it. This also lets us get rid of injection
    for findNodeHandle. Instead I move NativeMethodsMixin and ReactNativeComponent
    to use instantiation.
    * Refactor findHostInstance
    The reconciler shouldn't expose the Fiber data structure. We should pass
    the component instance to the reconciler, since the reconciler is the
    thing that is supposed to be instancemap aware.
    * Fix devtools injection
  * [RN] Move view config registry to shims ([#12569](https://github.com/facebook/react/issues/12569))
    * Move view config registry to shims
    This ensures that both Fabric and RN renderers share the same view config
    registry since it is stateful.
    I had to duplicate in the mocks for testing.
    * Move createReactNativeComponentClass to shims and delete internal usage
    Since createReactNativeComponentClass is just an alias for the register
    there's no need to bundle it. This file should probably just move back
    to RN too.
  * Consolidate eventTypes registry with view configs ([#12556](https://github.com/facebook/react/issues/12556))
    We already have one stateful module that contains all the view config.
    We might as well store the event types there too. That way the shared
    state is compartmentalized (and I can move it out in a follow up PR).
    The view config registry also already has an appropriate place to call
    processEventTypes so now we no longer have to do it in RN.
    Will follow up with a PR to RN to remove that call.
  * [RN] Remove unstable_batchedUpdates and unmountComponentAtNodeAndRemoveContainer from Fabric ([#12571](https://github.com/facebook/react/issues/12571))
    These don't make much sense in Fabric, since Fabric will be async by default only.
    And unmount+remove container is a sketchy API we should remove so we might
    as well make sure modern containers enforce that.
  * Remove ReactNativePropRegistry ([#12559](https://github.com/facebook/react/issues/12559))
    This has always been an unnecessary indirection to protect opaqueness,
    which hasn't really worked out.
  * Allocate unique reactTags for RN and Fabric ([#12587](https://github.com/facebook/react/issues/12587))
    Took this opportunity to remove some abstract overhead.
    In Fabric it is extra simple since they no longer overlap with root tags.
  * Throw more specific error if passed undefined in React.cloneElement ([#12534](https://github.com/facebook/react/issues/12534))
    * throw error if passed undefined
    * should be TypeError
    * simplify
    * use invariant
    * editor messed up spacing
    * better check
    * Revert "better check"
    This reverts commit 273370758eafa54d329577b3dc942c70587eccd3.
    * yarn prettier test was failing
    * more explicit copy
    * es6 import
    * tests
    * formatting
    * Move import
  * Unfork invariant and instead use it from reactProdInvariant ([#12585](https://github.com/facebook/react/issues/12585))
  * Preserve error codes for invariants on www ([#12539](https://github.com/facebook/react/issues/12539))
    * Preserve error codes for invariants on www
    * Remove unintentional change
  * Must be *a* before PlacementAndUpdate ([#12580](https://github.com/facebook/react/issues/12580))
  * Keep consistency in the comment ([#12579](https://github.com/facebook/react/issues/12579))
  * [RN] Move takeSnapshot to RN ([#12574](https://github.com/facebook/react/issues/12574))
    It only uses public APIs. I have a diff on the other side.
  * Support findNodeHandle in Fabric ([#12573](https://github.com/facebook/react/issues/12573))
    This doesn't actually need to share any state because it goes through
    the instance to the fiber structure. Since Fabric is on the same version
    as RN, calling it on either renderer works.
  * Remove flushSync from React Native ([#12565](https://github.com/facebook/react/issues/12565))
    There are no plans to enable async in the old renderer. In the new renderer
    it only really makes sense to do from the main thread and probably from
    native since it'll have to yield to native first.
  * Bug fix
  * Move TouchHistoryMath to React Native repo ([#12557](https://github.com/facebook/react/issues/12557))
    This isn't used by React core and is just a pure helper so it might as
    well live where it's used. The React Native repo.
  * Expose component stack from reactTag to React Native renderer ([#12549](https://github.com/facebook/react/issues/12549))
    This is not safe in general and therefore shouldn't be exposed to anything
    other than React Native internals.
    It will also need a different version in Fabric that will not have the
    reactTag exposed.
  * Clarify ReactDOM's case warning for html tags ([#12533](https://github.com/facebook/react/issues/12533))
    * update warning text
    * update tests to match
    * `yarn prettier`
    * include note on HTML5 custom elements
    * dan’s copy suggestion
    * remove ‘letters’
  * Removed Array.from() usage ([#12546](https://github.com/facebook/react/issues/12546))
  * Removed duplicate typeof check ([#12541](https://github.com/facebook/react/issues/12541))
  * facebook.github.io/react -> reactjs.org ([#12545](https://github.com/facebook/react/issues/12545))
  * Don't render bitmask-bailing consumers even if there's a deeper matching child ([#12543](https://github.com/facebook/react/issues/12543))
    * Don't render consumers that bailed out with bitmask even if there's a deeper matching child
    * Use a render prop in the test
    Without it, <Indirection> doesn't do anything because we bail out on constant element anyway.
    That's not what we're testing, and could be confusing.
  * Add a build step to hoist warning conditions ([#12537](https://github.com/facebook/react/issues/12537)).

</details>
<details>
  <summary> lodash  ^3.0.0  →  4.17.5 </summary>
  
.4.17.5 / 2018-02-04
===================

  * Cleanup compareAscending and remove hardcoded locale.
  * Support locales in sorting methods ([#3602](https://github.com/lodash/lodash/issues/3602))
  * Changed to function as documented. ([#3596](https://github.com/lodash/lodash/issues/3596))
  * Add the accepted customizer arguments to cloneDeepWith docs.
  * Update argument count for `cloneWith` customizer. [closes [#3582](https://github.com/lodash/lodash/issues/3582)]
  * rAF as default for debounce/throtte ([#3560](https://github.com/lodash/lodash/issues/3560)) ([#3567](https://github.com/lodash/lodash/issues/3567))
    Uses rAF by default for debounce/throtte unless `wait` is specified. ([#3560](https://github.com/lodash/lodash/issues/3560))
  * Enable _.words to detect ordinals in compound words. [closes [#3561](https://github.com/lodash/lodash/issues/3561)]
  * Remove duplicated "by which" words from the doc ([#3534](https://github.com/lodash/lodash/issues/3534))
  * feat(sideEffects): Set sideEffects false for opt. ([#3533](https://github.com/lodash/lodash/issues/3533))
    This adds the webpack v4 sideEffects optimization. Since we are now in alpha I wanted to help ensure this gets out there so people testing webpack v4 can see the instant wins. <3
  * Update license file with MIT title ([#3498](https://github.com/lodash/lodash/issues/3498))
  * Fix operator in `createMathOperation`. ([#3499](https://github.com/lodash/lodash/issues/3499))
  * Remove `map` examples from `parseInt` and `trim` ([#3487](https://github.com/lodash/lodash/issues/3487))
  * Tiny style correction in `createMathOperation`.
  * Revert "Fix typo in `escapeRegExp` ([#3448](https://github.com/lodash/lodash/issues/3448))"
    This reverts commit 102d9e34d71838c027b5fc3d9153187f50842c95.
  * Faster/simpler isPlainObject check ([#3483](https://github.com/lodash/lodash/issues/3483))
    Faster/simpler isPlainObject check.
    This runs up the prototype chain to check equivalency. When run in a cross-realm environment (differing contexts, iframes, etc), this ensures we're checking the value's prototype matches its context-specific instance of Object. 
    This is faster than calling `toString()` on the constructor. There's still the `baseGetTag()` call, which does its own `toString()`, but this swaps out one for cross-realm stuff. It's also a bit simpler to understand, I think.
  * Tiny performance improvement by not compiling regular expression each time ([#3479](https://github.com/lodash/lodash/issues/3479))
  * Fix typo in `inRange` ([#3478](https://github.com/lodash/lodash/issues/3478))
  * Modify the logic to make the code more intuitive ([#3472](https://github.com/lodash/lodash/issues/3472))
  * Fix [#3466](https://github.com/lodash/lodash/issues/3466) ([#3467](https://github.com/lodash/lodash/issues/3467))
  * Fix typo in `escapeRegExp` ([#3448](https://github.com/lodash/lodash/issues/3448))
  * Ignore log files that end with random numbers ([#3445](https://github.com/lodash/lodash/issues/3445))
  * Fix typo in `parseInt` ([#3433](https://github.com/lodash/lodash/issues/3433))
  * Remove trailing space in `sortedUniq`.
  * Remove semicolons from `dropRight`.
  * Add jsDelivr hits badge ([#3418](https://github.com/lodash/lodash/issues/3418))
  * Add missing keysIn import for baseClone.js ([#3413](https://github.com/lodash/lodash/issues/3413))
  * Verbiage change ([#3408](https://github.com/lodash/lodash/issues/3408))
    'T' missing in This.
  * Commit and whitespace nits in debounce.
  * Add pending() function to debounce and throttle to fix [#3387](https://github.com/lodash/lodash/issues/3387) ([#3388](https://github.com/lodash/lodash/issues/3388))
  * Fixes param definition ([#3368](https://github.com/lodash/lodash/issues/3368))
    Bitmask is number
  * Faster testing against first char in `stringToPath` (to close [#3308](https://github.com/lodash/lodash/issues/3308)).
  * clarify documentation about sortedUniq ([#3310](https://github.com/lodash/lodash/issues/3310))
    clarify that sortedUniq only works on sorted arrays
  * Fix typo in findKey.
  * Remove useless return in setToPairs. ([#3286](https://github.com/lodash/lodash/issues/3286))
  * avoid shadowing result ([#3280](https://github.com/lodash/lodash/issues/3280))
    related https://github.com/lodash/lodash/commit/e908519fc321829d6e43a1a40a791ce62e2fbc8c
  * _.update() docs grammar fix ([#3264](https://github.com/lodash/lodash/issues/3264))
  * Fixin loop args order regression from 3c2795b in `invertBy`.
  * Fixin loop args order regression from 3c2795b in `invert`.
  * Avoid using the values toString method in _.invert if it’s not a function. [closes [#3260](https://github.com/lodash/lodash/issues/3260)]
  * Update dropRight.js ([#3241](https://github.com/lodash/lodash/issues/3241))
  * stringToPath: avoid shadowing variable ([#3226](https://github.com/lodash/lodash/issues/3226))
    - remove the shadowing done using `string` variable declared in upper scope
  * default prefix to empty string ([#3214](https://github.com/lodash/lodash/issues/3214))
    This starting returning NaN for me. It looks like it is trying to add undefined + number when there is no prefix.
  * Support symbols in property paths of `set`. [closes [#3189](https://github.com/lodash/lodash/issues/3189)]
  * A better fix for `tag` scope in `baseClone`.
  * Fixin tag scope in `baseClone`.
  * Always use parentheses in arrow functions (fixin 67a3fb9).
  * Fix CoC link in .github/CONTRIBUTING.md ([#3156](https://github.com/lodash/lodash/issues/3156))
  * Complete wrapper modules removal for `setToString` (c6854fa).
  * Fix CoC link in REAMDE ([#3138](https://github.com/lodash/lodash/issues/3138))
  * Cleanup baseClone.
  * Fix cloneDeep with circularly dependent Sets/Maps ([#3123](https://github.com/lodash/lodash/issues/3123))
  * Update object checks.
  * Fixin `repeat` import.
  * Fixin `filter` imports.
  * Use `Array#splice` directly.
  * Remove `mergeData`.
  * Fixin `some` and `every` imports.
  * Fixin new `map` imports.
  * Remove `baseSlice`.
  * Fix typo in `find`.
  * Remove `baseKeys` and `baseKeysIn`.
  * Fix object coercion.
  * Fix typos.
  * Split `filter` out.
  * Simplify `mapKey` and `mapValue`.
  * Split `map` out.
  * Fix jsdoc for `every` and `some`.
  * Rename `mapKeys` and `mapValues` to `mapKey` and `mapValue`.
  * Proper `style` npm script execution ([#3103](https://github.com/lodash/lodash/issues/3103)).
  * Enable no-unexpected-multiline ([#3103](https://github.com/lodash/lodash/issues/3103))
    This rule can help catch errors introduced by automatic semicolon insertion
    edge cases. It seems like a sensible thing to have enabled in a code base that
    does not use semicolons.
    http://eslint.org/docs/rules/no-unexpected-multiline
  * Last spacing in template string expressions.
  * Adjust eslint settings to new requirements (d10b44b).
  * Rename `someValues` to `someValue`.
  * Split out `every` into `everyValue`.
  * Adjust spacing in template string expressions.
  * Remove `toSource`.
  * Remove internal `hasPath`.
  * Fixin scope range for var declarations in internal version of `hasPath`.
  * Use more for-of
  * Math them all.
  * Catch undeclared vars with eslint.
  * Fixin scope range for var declarations in `hasPath` and `hasPathIn`.
  * Fixin missing references in `repeat`.
  * Fixin declaration in `someValues` (571e752).
  * Fixin declaration in `baseSum` (3e2b0bb).
  * Remove `replaceHolders`.
  * Rename `someObj` to `someValues`.
  * Remove semicolons.
  * ESify `find` implementation.
  * Add `semi` option to eslint config..

</details>